### PR TITLE
Pass all party's nodeid, role, address into FL algorithm.

### DIFF
--- a/python/primihub/context.py
+++ b/python/primihub/context.py
@@ -124,6 +124,12 @@ class TaskContext:
         self.mk_output_dir(output_dir)
         print("guest lookup table: ", self.guest_lookup_file_path)
         return self.guest_lookup_file_path
+    
+    def get_role_node_map(self):
+        return self.role_nodeid_map
+
+    def get_node_addr_map(self):
+        return self.node_addr_map
 
 
 Context = TaskContext()
@@ -189,9 +195,14 @@ def reg_dataset(func):
 
 
 # Register task decorator
-def function(protocol, role, dataset_port_map):
+def function(protocol, role, datasets, port):
     def function_decorator(func):
         print("Register task:", func.__name__)
+
+        dataset_port_map = {}
+        for dataset in datasets:
+            dataset_port_map[dataset] = port
+
         Context.nodes_context[role] = NodeContext(
             role, protocol, dataset_port_map, func)
 


### PR DESCRIPTION
The scheduler only provide one address to guest and host, this makes it hard to adapt with LR algorithm. No matter LR is hetero LR or homo LR, a party should play as `arbiter` except  the host party and guest party, so LR algorithm need at least three party. And this also lose support for multiple party support even algorithm itself provide multiple party support.
This PR solve this problem, the basic idea is that maintain a map that saves dataset name and it's port and the scheduler will use it to help to provide all party's nodeid, address, role to algorithm. This sounds very strange: a dataset has a port? 
Primihub use dataset name to find all party during FL task,  we can think of a dataset name as a node, so the map of dataset name and port is the map of a node and it's port in FL. And no matter how `ph.context.function` change, as long as we can convert the dataset name and port argument into a map, the scheduler can provide all party's nodeid, address, role to algorithm. 