### PR TITLE
Support --user option in setup.py and pass taskid and jobid into python's context.

### DIFF
--- a/python/primihub/dataset/dataset.py
+++ b/python/primihub/dataset/dataset.py
@@ -28,6 +28,7 @@ from primihub.client.ph_grpc.src.primihub.protos import service_pb2
 from primihub.client.ph_grpc.src.primihub.protos import service_pb2_grpc
 
 def register_dataset(service_addr, driver, path, name):
+    logger.info("Dataset service is {}.".format(service_addr))
     channel = grpc.insecure_channel(service_addr)
     stub = service_pb2_grpc.DataServiceStub(channel)
     request = service_pb2.NewDatasetRequest()

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,8 +1,11 @@
 import os
+import sys
 import shlex
 import subprocess
+import shutil
 import sys
 import distutils
+import tempfile
 from distutils.sysconfig import get_python_lib
 from os import path
 import site
@@ -38,32 +41,44 @@ with open('requirements.txt', encoding='utf-8') as reqs:
 
 
 def solib2sitepackage(solib_path=None):
-    # add ../bazel-bin to PYTHONPATH on LINUX
-    print("ADD ../bazel-bin to PYTHONPATH on LINUX")
-    if not solib_path:
-        solib_path = path.abspath(path.join(path.dirname(__file__), "../bazel-bin"))  # noqa
-    SOLIB_PATH = solib_path
-    print("SOLIB_PATH: ", SOLIB_PATH)
-    print("* " * 30)
-    site_packages_path = get_python_lib()
-    print(site_packages_path)
-    pth_file = site_packages_path + "/primihub_so.pth"
-    print(pth_file)
-    try:
-        with open(pth_file, "w") as pth:
-            print("--", SOLIB_PATH)
-            pth.write(SOLIB_PATH)
-        site.addsitedir(SOLIB_PATH)
-        print("sys path: ", sys.path)
-    except Exception as e:
-        print(e)
+    if '--user' in sys.argv:
+        paths = site.getusersitepackages()
+    else:
+        paths = get_python_lib()
+
+    shutil.copyfile("../bazel-bin/opt_paillier_c2py.so", 
+                    paths + "/opt_paillier_c2py.so")
+
+
+def clean_proto():
+    os.chdir("../")
+    python_out_dir = "python/primihub/client/ph_grpc"
+    proto_dir = python_out_dir + "/src/primihub/protos/"
+
+    dir_files = os.listdir(proto_dir)
+    file_to_remove = []
+    for f_name in dir_files:
+        if f_name.find("pb2.py") != -1:
+            file_to_remove.append(f_name)
+        if f_name.find("pb2_grpc.py") != -1:
+            file_to_remove.append(f_name)
+    
+    for fname in file_to_remove:
+        os.remove(proto_dir + fname)
+        print("Remove {}.".format(fname))
+
+    os.chdir("python")
+    print(os.getcwd())
 
 
 def compile_proto():
     print("compile proto...")
+    os.chdir("../")
     print(os.getcwd())
-    os.chdir("..")
-    print(os.getcwd())
+    
+    python_out_dir = "python/primihub/client/ph_grpc"
+    grpc_python_out = "python/primihub/client/ph_grpc"
+
     cmd_str = """{pyexe} -m grpc_tools.protoc \
                         --python_out={python_out} \
                         --grpc_python_out={grpc_python_out} -I. \
@@ -71,8 +86,8 @@ def compile_proto():
                         src/primihub/protos/service.proto \
                         src/primihub/protos/worker.proto \
                         src/primihub/protos/pir.proto \
-                        src/primihub/protos/psi.proto""".format(python_out="python/primihub/client/ph_grpc",
-                                                                grpc_python_out="python/primihub/client/ph_grpc",
+                        src/primihub/protos/psi.proto""".format(python_out=python_out_dir,
+                                                                grpc_python_out=grpc_python_out,
                                                                 pyexe=sys.executable)
 
     print("cmd: %s" % cmd_str)
@@ -81,6 +96,7 @@ def compile_proto():
     out, err = p.communicate()
     if p.returncode != 0:
         raise RuntimeError("Error compiling proto file: {0}".format(err))
+    
     os.chdir("python")
     print(os.getcwd())
 
@@ -90,9 +106,10 @@ class PostDevelopCommand(develop):
 
     def run(self):
         # PUT YOUR POST-INSTALL SCRIPT HERE or CALL A FUNCTION
+        compile_proto()
         develop.run(self)
         solib2sitepackage()
-        compile_proto()
+        clean_proto()
 
 
 class PostInstallCommand(install):
@@ -100,9 +117,10 @@ class PostInstallCommand(install):
 
     def run(self):
         # PUT YOUR POST-INSTALL SCRIPT HERE or CALL A FUNCTION
+        compile_proto()
         install.run(self)
         solib2sitepackage()
-        compile_proto()
+        clean_proto()
 
 
 class ProtoCommand(distutils.cmd.Command):

--- a/python/setup.py
+++ b/python/setup.py
@@ -45,9 +45,12 @@ def solib2sitepackage(solib_path=None):
         paths = site.getusersitepackages()
     else:
         paths = get_python_lib()
-
-    shutil.copyfile("../bazel-bin/opt_paillier_c2py.so", 
-                    paths + "/opt_paillier_c2py.so")
+    
+    if os.path.isfile("../bazel-bin/opt_paillier_c2py.so"):
+        shutil.copyfile("../bazel-bin/opt_paillier_c2py.so", 
+                paths + "/opt_paillier_c2py.so")
+    else:
+        print("Ignore opt_paillier_c2py.so due to not compiled.")
 
 
 def clean_proto():

--- a/src/primihub/task/semantic/fl_task.cc
+++ b/src/primihub/task/semantic/fl_task.cc
@@ -135,6 +135,8 @@ FLTask::FLTask(const std::string& node_id,
     }
 
     this->params_map_["local_dataset"] = iter->second.value_string();
+    jobid_ = task_request.task().job_id();
+    taskid_ = task_request.task().task_id();
 }
 
 FLTask::~FLTask() {
@@ -185,8 +187,12 @@ int FLTask::execute() {
           auto pos = nodelet_addr.find(":");
           set_task_context_params_map("DatasetServiceAddr",
               nodelet_addr.substr(pos + 1, nodelet_addr.length()));
-        }
 
+          // Setup task id and job id.
+          set_task_context_params_map("jobid", jobid_);
+          set_task_context_params_map("taskid", taskid_);
+        }
+  
         set_task_context_params_map.release();
 
         // Run set_task_context_node_addr_map.

--- a/src/primihub/task/semantic/fl_task.h
+++ b/src/primihub/task/semantic/fl_task.h
@@ -42,6 +42,9 @@ class FLTask : public TaskBase {
     int execute() override;
 
   private:
+    std::string jobid_;
+    std::string taskid_;
+
     PushTaskRequest task_request_;
     std::string py_code_;
     NodeContext node_context_;


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/primihub/community#development-workflow) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.
- [ ] Please provide a readable PR title.

### Description
The setup.py will copy opt_paillier_c2py.so into python's system library directory even `--user` option added when run setup.py, fix it; The jobid and taskid will pass into python's context before python code launch.
