### PR TITLE
More user-friendly parameter names for arithmetic components

### DIFF
--- a/src/primihub/algorithm/arithmetic.cc
+++ b/src/primihub/algorithm/arithmetic.cc
@@ -187,7 +187,7 @@ int ArithmeticExecutor<Dbit>::loadParams(primihub::rpc::Task &task) {
       mpc_exec_ = new MPCExpressExecutor<Dbit>();
     }
 
-    std::string parties = param_map["Parties"].value_string();
+    std::string parties = param_map["RevealToParties"].value_string();
     spiltStr(parties, ";", tmp3);
     for (auto itr = tmp3.begin(); itr != tmp3.end(); itr++) {
       uint16_t party_id = 0;

--- a/src/primihub/node/node.cc
+++ b/src/primihub/node/node.cc
@@ -710,6 +710,10 @@ Status VMNodeImpl::SubmitTask(ServerContext *context,
     LOG(INFO) << str;
   }
   DispatchTask(*pushTaskRequest, pushTaskReply);
+
+  auto task_info = pushTaskReply->mutable_task_info();
+  task_info->CopyFrom(pushTaskRequest->task().task_info());
+
   return Status::OK;
 }
 


### PR DESCRIPTION
… ensure that the task context structure is properly populated within the PushTaskReply structure.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/primihub/community#development-workflow) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.
- [ ] Please provide a readable PR title.

### Description
1.Replace the term 'Parties' with 'RevealToParties' in the arithmetic component.
2.Populate the task context structure within the PushRequestReply structure.
