### PR TITLE
reduce communication overhead in Encoder

### DIFF
--- a/example/FL/preprocessing/hfl_onehotencoder.json
+++ b/example/FL/preprocessing/hfl_onehotencoder.json
@@ -1,6 +1,6 @@
 {
     "party_info": {
-        "task_manager": "127.0.0.1:50050"
+        "task_manager": "127.0.0.1:51050"
     },
     "component_params": {
         "roles": {
@@ -33,7 +33,7 @@
                     "drop": "if_binary",
                     "sparse_output": false,
                     "handle_unknown": "error",
-                    "min_frequency": 30,
+                    "min_frequency": null,
                     "max_categories": null,
                     "feature_name_combiner": "concat"
                 }

--- a/example/FL/preprocessing/hfl_onehotencoder.json
+++ b/example/FL/preprocessing/hfl_onehotencoder.json
@@ -1,6 +1,6 @@
 {
     "party_info": {
-        "task_manager": "127.0.0.1:51050"
+        "task_manager": "127.0.0.1:50050"
     },
     "component_params": {
         "roles": {

--- a/example/FL/preprocessing/hfl_ordinalencoder.json
+++ b/example/FL/preprocessing/hfl_ordinalencoder.json
@@ -1,6 +1,6 @@
 {
     "party_info": {
-        "task_manager": "127.0.0.1:50050"
+        "task_manager": "127.0.0.1:51050"
     },
     "component_params": {
         "roles": {

--- a/example/FL/preprocessing/hfl_ordinalencoder.json
+++ b/example/FL/preprocessing/hfl_ordinalencoder.json
@@ -1,6 +1,6 @@
 {
     "party_info": {
-        "task_manager": "127.0.0.1:51050"
+        "task_manager": "127.0.0.1:50050"
     },
     "component_params": {
         "roles": {

--- a/python/primihub/FL/preprocessing/util.py
+++ b/python/primihub/FL/preprocessing/util.py
@@ -6,6 +6,18 @@ from sklearn.utils._encode import MissingValues, _nandict, _NaNCounter
 from contextlib import suppress
 
 
+class RealNotInt(numbers.Real):
+    """A type that represents reals that are not instances of int.
+
+    Behaves like float, but also works with values extracted from numpy arrays.
+    isintance(1, RealNotInt) -> False
+    isinstance(1.0, RealNotInt) -> True
+    """
+
+
+RealNotInt.register(float)
+
+
 def is_constant_feature(var, mean, n_samples):
     """Detect if a feature is indistinguishable from a constant feature.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the [contribution guidelines](https://github.com/primihub/community#development-workflow)

Checklist
1. Make sure your request branch is not develop.
2. Please provide a readable PR title.
-->

**What does this implement/fix?**
<!-- Please describe what have you done in this pull request. -->
When only set `min_frequency`, clients can only send categories' counts below the threshold to sever.

**Any other comments?**

Moving the helper methods `_Hfit` into `_BaseEncoder`

<!-- Thanks for contributing to PrimiHub! -->