### PR TITLE
adjust the method to compute sample variance according to the params

### DIFF
--- a/python/primihub/FL/preprocessing/scaler.py
+++ b/python/primihub/FL/preprocessing/scaler.py
@@ -378,4 +378,8 @@ def variance(X_sum, un_var, n_samples):
 
 
 def sum_squares(Sm, Sn, Tm, Tn, m, n):
+    # Tony F. Chan, Gene H. Golub, and Randall J. Leveque.
+    # Algorithms for computing the sample variance: analysis
+    # and recommendations. The American Statistician, 1983.
+    # https://doi.org/10.2307/2683386
     return Sm + Sn + m / (n * (m + n)) * (n/m * Tm - Tn)**2


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the [contribution guidelines](https://github.com/primihub/community#development-workflow)

Checklist
1. Make sure your request branch is not develop.
2. Please provide a readable PR title.
-->

**Reference Issues/PRs**
<!-- Example: Fixes #1234. See also #3456. -->

**What does this implement/fix?**
<!-- Please describe what have you done in this pull request. -->
There are two types of methods to compute the sample variance.
The two-pass method, which basically compute the mean first, then compute the variance.
The one-pass method, which compute the global variance from the first order and second order statistics.

**Note**: both the two-pass and one-pass methods are numerically stable.

This have the following impact on `StandardScaler`:
- if `with_mean=True` and `with_std=True`, using **two-pass** method to compute variance
- if `with_mean=False` and `with_std=True`, using **one-pass** method to compute variance

**Any other comments?**

See https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance for more details.

<!-- Thanks for contributing to PrimiHub! -->