### PR TITLE
FIX replace infinity since it is not a valid JSON value

### DIFF
--- a/python/primihub/FL/metrics/classification.py
+++ b/python/primihub/FL/metrics/classification.py
@@ -52,6 +52,8 @@ def classification_metrics(y_true,
             metrics[prefix_name] = roc_auc_score(y_true, y_score, multi_class="ovr")
         elif name == "roc" and not multiclass:
             fpr, tpr, thresholds = roc_curve(y_true, y_score)
+            # thresholds[0] is np.inf, but is not a valid JSON value
+            thresholds[0] = thresholds[1] + 1.
             metrics[prefix + "fpr"] = fpr.tolist()
             metrics[prefix + "tpr"] = tpr.tolist()
             metrics[prefix + "thresholds"] = thresholds.tolist()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the [contribution guidelines](https://github.com/primihub/community#development-workflow)

Checklist
1. Make sure your request branch is not develop.
2. Please provide a readable PR title.
-->

**Reference Issues/PRs**
<!-- Example: Fixes #1234. See also #3456. -->

**What does this implement/fix?**
<!-- Please describe what have you done in this pull request. -->

The `thresholds[0]` is `np.inf` by default (returned by `roc_curve`).
Replace it by `thresholds[1]+1`, i.e., `max(y_score)+1`.

**Any other comments?**

<!-- Thanks for contributing to PrimiHub! -->